### PR TITLE
fix: Allowing SSH repo URIs

### DIFF
--- a/lib/forte/base.rb
+++ b/lib/forte/base.rb
@@ -2,7 +2,7 @@ class Base < Thor
   desc "print", "Prints the public keys to STDOUT"
   def print(uri)
     loc = RepoLocation.new(uri)
-    repo = Git.clone(loc.uri, File.join(Dir.pwd, './.tmp'))
+    repo = Git.clone(loc.uri, File.join(Dir.pwd, '.forte'))
     puts AuthorizedKeys.build(repo.dir.path)
     FileUtils.rm_rf(repo.dir.path)
   end

--- a/lib/forte/repo_location.rb
+++ b/lib/forte/repo_location.rb
@@ -6,6 +6,7 @@ class RepoLocation
   end
 
   def uri
+    return path if path.start_with?('git@')
     return path if path.start_with?('http')
     return path if Dir.exists?(File.join(path, '.git'))
     "https://github.com/#{path}.git"

--- a/lib/forte/version.rb
+++ b/lib/forte/version.rb
@@ -1,3 +1,3 @@
 module Forte
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/forte/repo_location_spec.rb
+++ b/spec/forte/repo_location_spec.rb
@@ -15,5 +15,9 @@ describe RepoLocation do
       repo = RepoLocation.new('yock/forte')
       expect(repo.uri).to eq('https://github.com/yock/forte.git')
     end
+    it 'returns ssh uris' do
+      repo = RepoLocation.new('git@github.com:yock/forte.git')
+      expect(repo.uri).to eq('git@github.com:yock/forte.git')
+    end
   end
 end


### PR DESCRIPTION
Previous version had no accomodation for SSH URIs, and concatenated them
into an HTTP uri, which was broken. This version addresses this bug.

Moved renamed temporary directory from .tmp to .forte to avoid
collisions with existing hidden temporary directories
